### PR TITLE
Move ErrorUtils handler to module scope

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,6 +19,12 @@ declare const global: {
   };
 } & typeof globalThis;
 
+// Register a global error handler immediately so even early errors are logged
+global.ErrorUtils?.setGlobalHandler((error, isFatal) => {
+  console.error('Global Error:', error.message);
+  console.error(error.stack);
+});
+
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
@@ -30,13 +36,6 @@ export default function RootLayout() {
     'Inter-SemiBold': Inter_600SemiBold,
     'Inter-Bold': Inter_700Bold,
   });
-
-  useEffect(() => {
-    global.ErrorUtils?.setGlobalHandler((error, isFatal) => {
-      console.error('Global Error:', error.message);
-      console.error(error.stack);
-    });
-  }, []);
 
   useEffect(() => {
     // Add logging to diagnose font loading issues


### PR DESCRIPTION
## Summary
- register global error handler at module load time

## Testing
- `npx prettier -w app/_layout.tsx`
- `npm run lint` *(fails: `expo: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68487ec710b88328a2465d11d32ba40b